### PR TITLE
Adds support for DEPLOYMENT_ENV variable

### DIFF
--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -17,7 +17,7 @@ defmodule Plugsnag do
             stacktrace = System.stacktrace
 
             exception
-            |> Bugsnag.report(release_stage: Atom.to_string(Mix.env))
+            |> Bugsnag.report(release_stage: System.get_env("DEPLOYMENT_ENV") || System.get_env("MIX_ENV"))
 
             reraise exception, stacktrace
         end


### PR DESCRIPTION
To be in sync with our own `bugsnag-elixir`, we need to support this
environment variable to have proper release stages reported to Bugsnag.
