### PR TITLE
Add redact/0 method to hide sensitive data

### DIFF
--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -15,7 +15,7 @@ defmodule Plugsnag do
         rescue
           exception ->
             metadata = %{"conn" => %{
-              "query_params" => Map.get(conn, :params),
+              "query_params" => Map.get(conn, :params) |> redact,
               "assigns"      => Map.get(conn, :assigns),
               "path_info"    => Map.get(conn, :path_info),
               "method"       => Map.get(conn, :method),
@@ -29,6 +29,18 @@ defmodule Plugsnag do
 
             reraise exception, System.stacktrace
         end
+      end
+
+      defp redact(params) do
+        put_in(params, redact_config.fields, redact_config.string)
+      end
+
+      defp redact_config do
+        defaults = %{fields: ~w(password), string: ~s([REDACTED])}
+
+        __MODULE__
+        |> Application.get_application
+        |> Application.get_env(:redact_config, defaults)
       end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Plugsnag.Mixfile do
 
   def project do
     [app: :plugsnag,
-     version: "1.0.1",
+     version: "1.2.0",
      elixir: "~> 1.0",
      package: package,
      description: """


### PR DESCRIPTION
Closes #3

[PLAT-589](https://talkdesk.atlassian.net/browse/PLAT-589)

---

By using `put_in/3`, we're able to redact sensitive data sent to Bugsnag. Check the following examples:

``` elixir
iex(1)> conn = %{params: %{password: "test", other: "test other"}}
%{params: %{other: "test other", password: "test"}}
iex(2)> Map.get(conn, :params)
%{other: "test other", password: "test"}
iex(3)> put_in(Map.get(conn, :params), [:password], "*************")
%{other: "test other", password: "*************"}
```
